### PR TITLE
Fix file read example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ $filesystem->getContents('test.txt')->then(function($contents) {
 Which is a convenience method for:
 
 ```php
-$filesystem->open('test.txt')->then(function($stream) {
+$filesystem->file('test.txt')->open('r')->then(function($stream) {
     return React\Stream\BufferedSink::createPromise($stream);
 })->then(function($contents) {
+    // ...
 });
 ```
 


### PR DESCRIPTION
This PR provides a fix for *reading the contents of a file* example in Readme. There is no such method `open($filename)` in `FilesystemInterface`, so I assume that there should be a chain of `file()` and `open()` calls.