### PR TITLE
Fix file stat for cases when file doesn't exist

### DIFF
--- a/src/WoolTrait.php
+++ b/src/WoolTrait.php
@@ -98,7 +98,7 @@ trait WoolTrait
     {
         if (!file_exists($payload['path'])) {
             return \React\Promise\reject([
-                'error' => 'Path doesn\'t exist',
+                'error' => ['message' => 'Path doesn\'t exist'],
             ]);
         }
 

--- a/tests/Adapters/FileTest.php
+++ b/tests/Adapters/FileTest.php
@@ -79,16 +79,18 @@ class FileTest extends AbstractAdaptersTest
     /**
      * @dataProvider filesystemProvider
      */
-    public function testDoesntExists(LoopInterface $loop, FilesystemInterface $filesystem)
+    public function testDoesntExist(LoopInterface $loop, FilesystemInterface $filesystem)
     {
         $this->setLoopTimeout($loop);
-        $result = false;
+        $rejectionReason = null;
+
         try {
-            $this->await($filesystem->file(__FILE__ . '.' . time())->exists(), $loop);
+            $this->await($filesystem->file(__FILE__ . '.' . time())->stat(), $loop);
         } catch (\Exception $e) {
-            $result = true;
+            $rejectionReason = $e->getMessage();
         }
-        $this->assertTrue($result);
+
+        $this->assertEquals("Path doesn't exist", $rejectionReason);
     }
 
     /**


### PR DESCRIPTION
When calling `exists()` or `stat()` on file object and a specified file doesn't exists the code fails. The reason is that everywhere in `React\Filesystem\WoolTrait` for rejecting promises is being used `error_get_last()` function. But when checking for existence you specify a custom array that has some different structure than the result of `error_get_last()`. In this case here it fails:

https://github.com/reactphp/filesystem/blob/master/src/ChildProcess/Adapter.php#L134

because there is no such key as `message`.