### PR TITLE
Add feature to rename directories

### DIFF
--- a/examples/directory_rename.php
+++ b/examples/directory_rename.php
@@ -1,0 +1,15 @@
+<?php
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+$filesystem = React\Filesystem\Filesystem::create($loop);
+$dir = $filesystem->dir('new');
+
+$dir->rename('new_name')->then(function(\React\Filesystem\Node\DirectoryInterface $newDir){
+    echo 'Renamed to ' . $newDir->getPath() . PHP_EOL;
+}, function(Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});
+
+$loop->run();

--- a/src/Node/Directory.php
+++ b/src/Node/Directory.php
@@ -164,6 +164,17 @@ class Directory implements DirectoryInterface
         return $this->adapter->rmdir($this->path);
     }
 
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rename($toDirectoryName)
+    {
+        return $this->adapter->rename($this->path, $toDirectoryName)->then(function () use ($toDirectoryName) {
+            return $this->filesystem->dir($toDirectoryName);
+        });
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Node/DirectoryInterface.php
+++ b/src/Node/DirectoryInterface.php
@@ -29,6 +29,14 @@ interface DirectoryInterface extends NodeInterface
     public function remove();
 
     /**
+     * Rename the directory and return the new directory through a promise
+     *
+     * @param string $toDirectoryName
+     * @return PromiseInterface<DirectoryInterface>
+     */
+    public function rename($toDirectoryName);
+
+    /**
      * List contents of the directory.
      *
      * @return PromiseInterface

--- a/tests/Node/DirectoryTest.php
+++ b/tests/Node/DirectoryTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Filesystem\Node;
 
+use React\EventLoop\Factory;
 use React\Filesystem\Filesystem;
 use React\Filesystem\Node\Directory;
 use React\Filesystem\Node\File;
@@ -79,6 +80,24 @@ class DirectoryTest extends TestCase
         ;
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', (new Directory($path, Filesystem::createFromAdapter($filesystem)))->create());
+    }
+
+    public function testRename()
+    {
+        $pathFrom = 'foo.bar';
+        $pathTo = 'bar.foo';
+        $filesystem = $this->mockAdapter();
+
+        $filesystem
+            ->expects($this->once())
+            ->method('rename')
+            ->with($pathFrom, $pathTo)
+            ->will($this->returnValue(new FulfilledPromise()))
+        ;
+
+        $newDirectory = \Clue\React\Block\await((new Directory($pathFrom, Filesystem::createFromAdapter($filesystem)))->rename($pathTo), Factory::create());
+        $this->assertInstanceOf('React\Filesystem\Node\DirectoryInterface', $newDirectory);
+        $this->assertSame($pathTo . NodeInterface::DS, $newDirectory->getPath());
     }
 
     public function testRemove()


### PR DESCRIPTION
This PR extends `DirectoryInterface` and adds method to `rename()` current directory object. The api is the same as `FileInterface` has:

```php
$loop = Factory::create();
$filesystem = Filesystem::create($loop);
$dir = $filesystem->dir('new');

$dir->rename('new_name')->then(function(\React\Filesystem\Node\DirectoryInterface $newDir){
    echo 'Renamed to ' . $newDir->getPath() . PHP_EOL;
}, function(Exception $e) {
    echo 'Error: ' . $e->getMessage() . PHP_EOL;
});
```