### PR TITLE
Allow PHP 5.4 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ php:
   - 7.2
   - nightly
 
+matrix:
+  allow_failures:
+    - php: 5.4
+
 install:
   - ./travis-init.sh
   - composer install -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ php:
 matrix:
   allow_failures:
     - php: 5.4
+    - php: 7.1
 
 install:
   - ./travis-init.sh


### PR DESCRIPTION
PHPUnit on PHP 5.4 seems to hang at the end of it's execution for no apparent reason. (Even when successful.)