### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4 - part deux 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -929,16 +929,16 @@
         },
         {
             "name": "wyrihaximus/react-child-process-pool",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WyriHaximus/reactphp-child-process-pool.git",
-                "reference": "85e07c48e007e28beec1a47e63686db219d44e87"
+                "reference": "232f2aef55ce6df816f837442e79ff2976ebc8ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WyriHaximus/reactphp-child-process-pool/zipball/85e07c48e007e28beec1a47e63686db219d44e87",
-                "reference": "85e07c48e007e28beec1a47e63686db219d44e87",
+                "url": "https://api.github.com/repos/WyriHaximus/reactphp-child-process-pool/zipball/232f2aef55ce6df816f837442e79ff2976ebc8ed",
+                "reference": "232f2aef55ce6df816f837442e79ff2976ebc8ed",
                 "shasum": ""
             },
             "require": {
@@ -977,7 +977,7 @@
                     "email": "ceesjank@gmail.com"
                 }
             ],
-            "time": "2018-02-28T20:22:20+00:00"
+            "time": "2018-04-23T17:21:00+00:00"
         },
         {
             "name": "wyrihaximus/react-child-process-promise",
@@ -1030,16 +1030,16 @@
         },
         {
             "name": "wyrihaximus/ticking-promise",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WyriHaximus/TickingPromise.git",
-                "reference": "6b9f9abc74bb52ba3a479f8d3b8889579cd2cd6f"
+                "reference": "4bb99024402bb7526de8880f3dab0c1f0858def5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WyriHaximus/TickingPromise/zipball/6b9f9abc74bb52ba3a479f8d3b8889579cd2cd6f",
-                "reference": "6b9f9abc74bb52ba3a479f8d3b8889579cd2cd6f",
+                "url": "https://api.github.com/repos/WyriHaximus/TickingPromise/zipball/4bb99024402bb7526de8880f3dab0c1f0858def5",
+                "reference": "4bb99024402bb7526de8880f3dab0c1f0858def5",
                 "shasum": ""
             },
             "require": {
@@ -1073,7 +1073,7 @@
                 }
             ],
             "description": "Wrapping ticks into a promise",
-            "time": "2017-10-31T21:46:39+00:00"
+            "time": "2018-04-05T12:36:50+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Node/Directory.php
+++ b/src/Node/Directory.php
@@ -3,7 +3,6 @@
 namespace React\Filesystem\Node;
 
 use Evenement\EventEmitterTrait;
-use React\EventLoop\Timer\TimerInterface;
 use React\Filesystem\AdapterInterface;
 use React\Filesystem\FilesystemInterface;
 use React\Filesystem\ObjectStream;
@@ -258,9 +257,9 @@ class Directory implements DirectoryInterface
         });
 
         $sourceStream->on('end', function () use (&$closeCount, $stream) {
-            $this->adapter->getLoop()->addPeriodicTimer(0.01, function (TimerInterface $timer) use (&$closeCount, $stream) {
+            $this->adapter->getLoop()->addPeriodicTimer(0.01, function ($timer) use (&$closeCount, $stream) {
                 if ($closeCount === 0) {
-                    $timer->cancel();
+                    $this->adapter->getLoop()->cancelTimer($timer);
                     $stream->close();
                 }
             });

--- a/tests/Eio/AdapterTest.php
+++ b/tests/Eio/AdapterTest.php
@@ -441,9 +441,23 @@ class AdapterTest extends TestCase
 
     public function testExecuteDelayedCall()
     {
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', [
-            'futureTick',
+        $loop = $this->getMock('React\EventLoop\LoopInterface', [
             'addReadStream',
+            'addWriteStream',
+            'removeReadStream',
+            'removeWriteStream',
+            'removeStream',
+            'addTimer',
+            'addPeriodicTimer',
+            'cancelTimer',
+            'isTimerActive',
+            'nextTick',
+            'futureTick',
+            'tick',
+            'run',
+            'stop',
+            'addSignal',
+            'removeSignal',
         ]);
 
         $filesystem = new Adapter($loop);
@@ -486,9 +500,23 @@ class AdapterTest extends TestCase
 
     public function testExecuteDelayedCallFailed()
     {
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', [
-            'futureTick',
+        $loop = $this->getMock('React\EventLoop\LoopInterface', [
             'addReadStream',
+            'addWriteStream',
+            'removeReadStream',
+            'removeWriteStream',
+            'removeStream',
+            'addTimer',
+            'addPeriodicTimer',
+            'cancelTimer',
+            'isTimerActive',
+            'nextTick',
+            'futureTick',
+            'tick',
+            'run',
+            'stop',
+            'addSignal',
+            'removeSignal',
         ]);
 
         $filesystem = new Adapter($loop);
@@ -529,9 +557,23 @@ class AdapterTest extends TestCase
 
     public function testExecuteDelayedCallFailedResult()
     {
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', [
-            'futureTick',
+        $loop = $this->getMock('React\EventLoop\LoopInterface', [
             'addReadStream',
+            'addWriteStream',
+            'removeReadStream',
+            'removeWriteStream',
+            'removeStream',
+            'addTimer',
+            'addPeriodicTimer',
+            'cancelTimer',
+            'isTimerActive',
+            'nextTick',
+            'futureTick',
+            'tick',
+            'run',
+            'stop',
+            'addSignal',
+            'removeSignal',
         ]);
 
         $filesystem = new Adapter($loop);
@@ -572,9 +614,23 @@ class AdapterTest extends TestCase
 
     public function testUnregister()
     {
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', [
-            'futureTick',
+        $loop = $this->getMock('React\EventLoop\LoopInterface', [
+            'addReadStream',
+            'addWriteStream',
             'removeReadStream',
+            'removeWriteStream',
+            'removeStream',
+            'addTimer',
+            'addPeriodicTimer',
+            'cancelTimer',
+            'isTimerActive',
+            'nextTick',
+            'futureTick',
+            'tick',
+            'run',
+            'stop',
+            'addSignal',
+            'removeSignal',
         ]);
 
         $filesystem = $this->getMock('React\Filesystem\Eio\Adapter', [
@@ -625,8 +681,23 @@ class AdapterTest extends TestCase
 
     public function testUnregisterInactive()
     {
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop', [
+        $loop = $this->getMock('React\EventLoop\LoopInterface', [
+            'addReadStream',
+            'addWriteStream',
             'removeReadStream',
+            'removeWriteStream',
+            'removeStream',
+            'addTimer',
+            'addPeriodicTimer',
+            'cancelTimer',
+            'isTimerActive',
+            'nextTick',
+            'futureTick',
+            'tick',
+            'run',
+            'stop',
+            'addSignal',
+            'removeSignal',
         ]);
 
         $filesystem = $this->getMock('React\Filesystem\Eio\Adapter', [

--- a/tests/Eio/ConstTypeDetectorTest.php
+++ b/tests/Eio/ConstTypeDetectorTest.php
@@ -32,7 +32,7 @@ class ConstTypeDetectorTest extends TestCase
     {
         $callbackFired = false;
 
-        $filesystem = Filesystem::create($this->getMock('React\EventLoop\StreamSelectLoop'), [
+        $filesystem = Filesystem::create($this->getMock('React\EventLoop\LoopInterface'), [
             'pool' => [
                 'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
             ],
@@ -54,7 +54,7 @@ class ConstTypeDetectorTest extends TestCase
     {
         $callbackFired = false;
 
-        $filesystem = Filesystem::create($this->getMock('React\EventLoop\StreamSelectLoop'), [
+        $filesystem = Filesystem::create($this->getMock('React\EventLoop\LoopInterface'), [
             'pool' => [
                 'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
             ],

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -13,7 +13,7 @@ class FilesystemTest extends TestCase
     {
         $this->assertInstanceOf(
             'React\Filesystem\Filesystem',
-            Filesystem::create($this->getMock('React\EventLoop\StreamSelectLoop'), [
+            Filesystem::create($this->getMock('React\EventLoop\LoopInterface'), [
                 'pool' => [
                     'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
                 ],
@@ -45,7 +45,7 @@ class FilesystemTest extends TestCase
 
     public function testFile()
     {
-        $file = Filesystem::create($this->getMock('React\EventLoop\StreamSelectLoop'), [
+        $file = Filesystem::create($this->getMock('React\EventLoop\LoopInterface'), [
             'pool' => [
                 'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
             ],
@@ -56,7 +56,7 @@ class FilesystemTest extends TestCase
 
     public function testDir()
     {
-        $directory = Filesystem::create($this->getMock('React\EventLoop\StreamSelectLoop'), [
+        $directory = Filesystem::create($this->getMock('React\EventLoop\LoopInterface'), [
             'pool' => [
                 'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
             ],

--- a/tests/Node/DirectoryTest.php
+++ b/tests/Node/DirectoryTest.php
@@ -41,7 +41,7 @@ class DirectoryTest extends TestCase
     public function testLs()
     {
         $path = '/home/foo/bar';
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop');
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $filesystem = $this->mockAdapter($loop);
 
@@ -118,7 +118,7 @@ class DirectoryTest extends TestCase
     public function testSize()
     {
         $path = '/home/foo/bar';
-        $loop = $this->getMock('React\EventLoop\StreamSelectLoop');
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
 
         $filesystem = $this->mockAdapter($loop);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,7 @@ class TestCase extends PHPUnitTestCase
     protected function mockAdapter(LoopInterface $loop = null)
     {
         if ($loop === null) {
-            $loop = $this->getMock('React\EventLoop\StreamSelectLoop');
+            $loop = $this->getMock('React\EventLoop\LoopInterface');
         }
 
         $mock = $this->getMock('React\Filesystem\AdapterInterface', [


### PR DESCRIPTION
Jumped the gun with #35 and in my enthusiasm I forgot to add the required code changes. This PR adds those missing changes. My apologies 