### PR TITLE
Add supported adapters static method

### DIFF
--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -8,6 +8,13 @@ use React\Promise\PromiseInterface;
 interface AdapterInterface
 {
     const CREATION_MODE = 'rwxrw----';
+    
+    /**
+     * Checks whether the current installation supports the adapter.
+     *
+     * @return boolean
+     */
+    public static function isSupported();
 
     /**
      * Return the loop associated with this adapter.

--- a/src/ChildProcess/Adapter.php
+++ b/src/ChildProcess/Adapter.php
@@ -91,6 +91,14 @@ class Adapter extends AbstractSyncAdapter implements AdapterInterface
     }
 
     /**
+     * @return boolean
+     */
+    public static function isSupported()
+    {
+        return substr(strtolower(PHP_OS), 0, 3) !== 'win' && function_exists('proc_open');
+    }
+
+    /**
      * @return LoopInterface
      */
     public function getLoop()

--- a/src/Eio/Adapter.php
+++ b/src/Eio/Adapter.php
@@ -103,6 +103,14 @@ class Adapter implements AdapterInterface
     }
 
     /**
+     * @return boolean
+     */
+    public static function isSupported()
+    {
+        return extension_loaded('eio');
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getLoop()

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -2,6 +2,7 @@
 
 namespace React\Filesystem;
 
+use RuntimeException;
 use React\EventLoop\LoopInterface;
 use React\Filesystem\Node;
 
@@ -11,6 +12,7 @@ interface FilesystemInterface
      * @param LoopInterface $loop
      * @param array $options
      * @return FilesystemInterface
+     * @throws RuntimeException
      */
     public static function create(LoopInterface $loop, array $options = []);
 
@@ -19,6 +21,11 @@ interface FilesystemInterface
      * @return static
      */
     public static function createFromAdapter(AdapterInterface $adapter);
+
+    /**
+     * @return string[]
+     */
+    public static function getSupportedAdapters();
 
     /**
      * @return AdapterInterface

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ class TestCase extends PHPUnitTestCase
             'setFilesystem',
             'setInvoker',
             'callFilesystem',
+            'isSupported',
             'mkdir',
             'rmdir',
             'unlink',


### PR DESCRIPTION
This PR adds a method to the Filesystem Interface to get the supported adapters of the current installation. The Adapter Interface gets a new method to determine whether the adapter is supported on the current installation.

This PR closes #32. Replaces PR #33.