### PR TITLE
Drop `EIO_O_FSYNC` as EIO doesn't support it anymore

### DIFF
--- a/src/Eio/OpenFlagResolver.php
+++ b/src/Eio/OpenFlagResolver.php
@@ -14,7 +14,6 @@ class OpenFlagResolver extends FlagResolver implements FlagResolverInterface
         'a' => EIO_O_APPEND,
         'c' => EIO_O_CREAT,
         'e' => EIO_O_EXCL,
-        'f' => EIO_O_FSYNC,
         'n' => EIO_O_NONBLOCK,
         'r' => EIO_O_RDONLY,
         't' => EIO_O_TRUNC,


### PR DESCRIPTION
Closes #34 

As mentioned in #34 and at https://pecl.php.net/package-changelog.php?package=eio&release=2.0.2 this constant has been removed so we can't rely on it.