### PR TITLE
Change promise usage to recommendation

### DIFF
--- a/src/AbstractSyncAdapter.php
+++ b/src/AbstractSyncAdapter.php
@@ -3,13 +3,9 @@
 namespace React\Filesystem;
 
 use DateTime;
+use LogicException;
 use React\Filesystem\Node\NodeInterface;
-use React\Filesystem\Stream\StreamFactory;
-use React\Promise\FulfilledPromise;
 use React\Promise\PromiseInterface;
-use React\Promise\RejectedPromise;
-use WyriHaximus\React\ChildProcess\Messenger\Messages\Factory;
-use WyriHaximus\React\ChildProcess\Messenger\Messenger;
 
 abstract class AbstractSyncAdapter implements AdapterInterface
 {
@@ -123,8 +119,6 @@ abstract class AbstractSyncAdapter implements AdapterInterface
             ];
             $promises[] = \React\Filesystem\detectType($this->typeDetectors, $node)->then(function (NodeInterface $node) use ($stream) {
                 $stream->write($node);
-
-                return new FulfilledPromise();
             });
         }
 
@@ -154,19 +148,7 @@ abstract class AbstractSyncAdapter implements AdapterInterface
      */
     public function open($path, $flags, $mode = self::CREATION_MODE)
     {
-        return new RejectedPromise();
-        $id = null;
-        return \WyriHaximus\React\ChildProcess\Messenger\Factory::parentFromClass(self::CHILD_CLASS_NAME, $this->loop)->then(function (Messenger $messenger) use (&$id, $path, $flags, $mode) {
-            $id = count($this->fileDescriptors);
-            $this->fileDescriptors[$id] = $messenger;
-            return $this->fileDescriptors[$id]->rpc(Factory::rpc('open', [
-                'path' => $path,
-                'flags' => $flags,
-                'mode' => $mode,
-            ]));
-        })->then(function () use ($path, $flags, &$id) {
-            return \React\Promise\resolve(StreamFactory::create($path, $id, $flags, $this));
-        });
+        return \React\Promise\reject(new LogicException('Not implemented'));
     }
 
     /**
@@ -177,13 +159,7 @@ abstract class AbstractSyncAdapter implements AdapterInterface
      */
     public function read($fileDescriptor, $length, $offset)
     {
-        return new RejectedPromise();
-        return $this->fileDescriptors[$fileDescriptor]->rpc(Factory::rpc('read', [
-            'length' => $length,
-            'offset' => $offset,
-        ]))->then(function ($payload) {
-            return \React\Promise\resolve($payload['chunk']);
-        });
+        return \React\Promise\reject(new LogicException('Not implemented'));
     }
 
     /**
@@ -195,12 +171,7 @@ abstract class AbstractSyncAdapter implements AdapterInterface
      */
     public function write($fileDescriptor, $data, $length, $offset)
     {
-        return new RejectedPromise();
-        return $this->fileDescriptors[$fileDescriptor]->rpc(Factory::rpc('write', [
-            'chunk' => $data,
-            'length' => $length,
-            'offset' => $offset,
-        ]));
+        return \React\Promise\reject(new LogicException('Not implemented'));
     }
 
     /**
@@ -209,14 +180,7 @@ abstract class AbstractSyncAdapter implements AdapterInterface
      */
     public function close($fd)
     {
-        return new RejectedPromise();
-        $fileDescriptor = $this->fileDescriptors[$fd];
-        unset($this->fileDescriptors[$fd]);
-        return $fileDescriptor->rpc(Factory::rpc('close'))->then(function () use ($fileDescriptor) {
-            return $fileDescriptor->softTerminate();
-        }, function () use ($fileDescriptor) {
-            return $fileDescriptor->softTerminate();
-        });
+        return \React\Promise\reject(new LogicException('Not implemented'));
     }
 
     /**

--- a/src/Eio/Adapter.php
+++ b/src/Eio/Adapter.php
@@ -15,7 +15,6 @@ use React\Filesystem\PermissionFlagResolver;
 use React\Filesystem\Stream\StreamFactory;
 use React\Filesystem\TypeDetectorInterface;
 use React\Promise\Deferred;
-use React\Promise\FulfilledPromise;
 
 class Adapter implements AdapterInterface
 {
@@ -228,8 +227,6 @@ class Adapter implements AdapterInterface
             ];
             $promises[] = \React\Filesystem\detectType($this->typeDetectors, $node)->then(function (NodeInterface $node) use ($stream) {
                 $stream->write($node);
-
-                return new FulfilledPromise();
             });
         }
 

--- a/src/Eio/ConstTypeDetector.php
+++ b/src/Eio/ConstTypeDetector.php
@@ -2,9 +2,9 @@
 
 namespace React\Filesystem\Eio;
 
+use Exception;
 use React\Filesystem\FilesystemInterface;
 use React\Filesystem\TypeDetectorInterface;
-use React\Promise\RejectedPromise;
 
 class ConstTypeDetector implements TypeDetectorInterface
 {
@@ -37,7 +37,7 @@ class ConstTypeDetector implements TypeDetectorInterface
     public function detect(array $node)
     {
         if (!isset($node['type']) || !isset($this->mapping[$node['type']])) {
-            return new RejectedPromise();
+            return \React\Promise\reject(new Exception('Unknown node type'));
         }
 
         return \React\Promise\resolve([

--- a/src/MappedTypeDetector.php
+++ b/src/MappedTypeDetector.php
@@ -2,7 +2,7 @@
 
 namespace React\Filesystem;
 
-use React\Promise\RejectedPromise;
+use Exception;
 
 class MappedTypeDetector implements TypeDetectorInterface
 {
@@ -52,7 +52,7 @@ class MappedTypeDetector implements TypeDetectorInterface
     public function detect(array $node)
     {
         if (!isset($node['type']) || !isset($this->mapping[$node['type']])) {
-            return new RejectedPromise();
+            return \React\Promise\reject(new Exception('Unknown type'));
         }
 
         return \React\Promise\resolve([

--- a/src/ModeTypeDetector.php
+++ b/src/ModeTypeDetector.php
@@ -2,9 +2,9 @@
 
 namespace React\Filesystem;
 
+use Exception;
 use React\Filesystem\FilesystemInterface;
 use React\Filesystem\TypeDetectorInterface;
-use React\Promise\RejectedPromise;
 
 class ModeTypeDetector implements TypeDetectorInterface
 {
@@ -43,7 +43,7 @@ class ModeTypeDetector implements TypeDetectorInterface
 
     protected function walkMapping($stat)
     {
-        $promiseChain = new RejectedPromise();
+        $promiseChain = \React\Promise\reject(new Exception('Unknown type'));
         foreach ($this->mapping as $mappingMode => $method) {
             $promiseChain = $promiseChain->otherwise(function () use ($stat, $mappingMode, $method) {
                 return $this->matchMapping($stat['mode'], $mappingMode, $method);
@@ -61,6 +61,6 @@ class ModeTypeDetector implements TypeDetectorInterface
             ]);
         }
 
-        return new RejectedPromise();
+        return \React\Promise\reject(new Exception('Unknown filesystem method for type'));
     }
 }

--- a/src/Node/Directory.php
+++ b/src/Node/Directory.php
@@ -8,7 +8,6 @@ use React\Filesystem\FilesystemInterface;
 use React\Filesystem\ObjectStream;
 use React\Filesystem\ObjectStreamSink;
 use React\Promise\Deferred;
-use React\Promise\FulfilledPromise;
 
 class Directory implements DirectoryInterface
 {
@@ -114,7 +113,6 @@ class Directory implements DirectoryInterface
                             $numbers['directories'] += $size['directories'];
                             $numbers['files'] += $size['files'];
                             $numbers['size'] += $size['size'];
-                            return new FulfilledPromise();
                         });
                     }
                     break;
@@ -122,7 +120,6 @@ class Directory implements DirectoryInterface
                     $numbers['files']++;
                     $promises[] = $node->size()->then(function ($size) use (&$numbers) {
                         $numbers['size'] += $size;
-                        return new FulfilledPromise();
                     });
                     break;
             }
@@ -189,7 +186,7 @@ class Directory implements DirectoryInterface
         })->then(function () use ($mode) {
             return $this->create($mode);
         })->then(function () {
-            return new FulfilledPromise();
+            return null;
         });
     }
 

--- a/src/OpenFileLimiter.php
+++ b/src/OpenFileLimiter.php
@@ -3,7 +3,6 @@
 namespace React\Filesystem;
 
 use React\Promise\Deferred;
-use React\Promise\FulfilledPromise;
 
 class OpenFileLimiter
 {
@@ -43,7 +42,7 @@ class OpenFileLimiter
     {
         if ($this->current < $this->limit) {
             $this->current++;
-            return new FulfilledPromise();
+            return \React\Promise\resolve();
         }
 
         $deferred = new Deferred();

--- a/src/Stream/DuplexStream.php
+++ b/src/Stream/DuplexStream.php
@@ -5,7 +5,6 @@ namespace React\Filesystem\Stream;
 use Evenement\EventEmitter;
 use React\Filesystem\AdapterInterface;
 use React\Stream\DuplexStreamInterface;
-use React\Promise\FulfilledPromise;
 
 class DuplexStream extends EventEmitter implements DuplexStreamInterface, GenericStreamInterface
 {
@@ -39,12 +38,11 @@ class DuplexStream extends EventEmitter implements DuplexStreamInterface, Generi
     protected function resolveSize()
     {
         if ($this->readCursor < $this->size) {
-            return new FulfilledPromise();
+            return \React\Promise\resolve();
         }
 
         return $this->getFilesystem()->stat($this->path)->then(function ($stat) {
             $this->size = $stat['size'];
-            return new FulfilledPromise();
         });
     }
 }

--- a/src/Stream/ReadableStreamTrait.php
+++ b/src/Stream/ReadableStreamTrait.php
@@ -2,8 +2,7 @@
 
 namespace React\Filesystem\Stream;
 
-use React\Promise\FulfilledPromise;
-use React\Promise\RejectedPromise;
+use Exception;
 use React\Stream\Util;
 use React\Stream\WritableStreamInterface;
 
@@ -27,11 +26,11 @@ trait ReadableStreamTrait
         if ($this->size === null && $this->sizeLookupPromise === null) {
             $this->sizeLookupPromise = $this->getFilesystem()->stat($this->getPath())->then(function ($info) {
                 if ($this->size !== null) {
-                    return new RejectedPromise();
+                    throw new Exception('File was already stat-ed');
                 }
+
                 $this->size = $info['size'];
                 $this->readCursor = 0;
-                return new FulfilledPromise();
             });
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,7 +2,7 @@
 
 namespace React\Filesystem;
 
-use React\Promise\RejectedPromise;
+use Exception;
 
 /**
  * @param AdapterInterface $adapter
@@ -40,7 +40,7 @@ function getOpenFileLimit(array $options)
  */
 function detectType(array $typeDetectors, array $node)
 {
-    $promiseChain = new RejectedPromise();
+    $promiseChain = \React\Promise\reject(new Exception('Unknown type'));
     foreach ($typeDetectors as $detector) {
         $promiseChain = $promiseChain->otherwise(function () use ($node, $detector) {
             return $detector->detect($node);

--- a/tests/Eio/ConstTypeDetectorTest.php
+++ b/tests/Eio/ConstTypeDetectorTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Filesystem\Eio;
 
+use Exception;
 use React\Filesystem\Eio\ConstTypeDetector;
 use React\Filesystem\Filesystem;
 use React\Tests\Filesystem\TestCase;
@@ -62,7 +63,7 @@ class ConstTypeDetectorTest extends TestCase
         (new ConstTypeDetector($filesystem))->detect([
             'type' => 123,
         ])->otherwise(function ($result) use (&$callbackFired) {
-            $this->assertNull($result);
+            $this->assertInstanceOf('Exception', $result);
             $callbackFired = true;
         });
 

--- a/tests/ModeTypeDetectorTest.php
+++ b/tests/ModeTypeDetectorTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Filesystem;
 
+use Exception;
 use React\Filesystem\Filesystem;
 use React\Filesystem\ModeTypeDetector;
 use React\Promise\FulfilledPromise;
@@ -69,7 +70,7 @@ class ModeTypeDetectorTest extends TestCase
         (new ModeTypeDetector($filesystem))->detect([
             'path' => 'foo.bar',
         ])->otherwise(function ($result) use (&$callbackFired) {
-            $this->assertNull($result);
+            $this->assertInstanceOf('Exception', $result);
             $callbackFired = true;
         });
 

--- a/tests/Node/FileTest.php
+++ b/tests/Node/FileTest.php
@@ -85,16 +85,7 @@ class FileTest extends TestCase
             Filesystem::createFromAdapter($filesystem),
         ]);
 
-        $promise = $this->getMock('React\Promise\PromiseInterface');
-
-        $promise
-            ->expects($this->once())
-            ->method('then')
-            ->with($this->isType('callable'))
-            ->will($this->returnCallback(function ($resolveCb) {
-                return $resolveCb();
-            }))
-        ;
+        $promise = \React\Promise\resolve();
 
         $file
             ->expects($this->once())
@@ -118,16 +109,7 @@ class FileTest extends TestCase
             Filesystem::createFromAdapter($filesystem),
         ]);
 
-        $promise = $this->getMock('React\Promise\PromiseInterface');
-
-        $promise
-            ->expects($this->once())
-            ->method('then')
-            ->with($this->isType('callable'))
-            ->will($this->returnCallback(function ($null, $resolveCb) {
-                return $resolveCb();
-            }))
-        ;
+        $promise = \React\Promise\resolve();
 
         $file
             ->expects($this->once())
@@ -241,7 +223,7 @@ class FileTest extends TestCase
         $callbackFired = false;
         (new File($path, Filesystem::createFromAdapter($filesystem)))->create()->then(null, function ($e) use (&$callbackFired) {
             $this->assertInstanceOf('Exception', $e);
-            $this->assertSame('File exists', $e->getMessage());
+            $this->assertSame('File exists already', $e->getMessage());
             $callbackFired = true;
         });
 


### PR DESCRIPTION
This PR is a split of the original PR #45 (the original PR shall stay open until completely done).

This PR changes the usage of promises inside this library to the recommendation listed on reactphp/promise. This PR also removes the unreachable code in `AbstractSyncAdapter` and adds exceptions to rejected promises.

The used promises in the tests are untouched, as they will be refactored anyway in a future PR.