### PR TITLE
Move stream factory creation to node

### DIFF
--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -8,11 +8,11 @@ use React\Promise\PromiseInterface;
 interface AdapterInterface
 {
     const CREATION_MODE = 'rwxrw----';
-    
+
     /**
      * Checks whether the current installation supports the adapter.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isSupported();
 
@@ -127,7 +127,7 @@ interface AdapterInterface
      * @param string $path
      * @param string $flags
      * @param $mode
-     * @return PromiseInterface<file descriptor>
+     * @return PromiseInterface
      */
     public function open($path, $flags, $mode = self::CREATION_MODE);
 

--- a/src/ChildProcess/Adapter.php
+++ b/src/ChildProcess/Adapter.php
@@ -15,7 +15,6 @@ use React\Filesystem\OpenFileLimiter;
 use React\Filesystem\TypeDetectorInterface;
 use React\Filesystem\PermissionFlagResolver;
 use React\Filesystem\Node\NodeInterface;
-use React\Filesystem\Stream\StreamFactory;
 use React\Promise\PromiseInterface;
 use WyriHaximus\React\ChildProcess\Messenger\Messages\Factory;
 use WyriHaximus\React\ChildProcess\Messenger\Messages\Payload;
@@ -212,8 +211,8 @@ class Adapter implements AdapterInterface
                 'flags' => $flags,
                 'mode' => $mode,
             ]));
-        })->then(function () use ($path, $flags, &$id) {
-            return \React\Promise\resolve(StreamFactory::create($path, $id, $flags, $this));
+        })->then(function () use (&$id) {
+            return $id;
         });
     }
 

--- a/src/Eio/Adapter.php
+++ b/src/Eio/Adapter.php
@@ -12,7 +12,6 @@ use React\Filesystem\Node\NodeInterface;
 use React\Filesystem\ObjectStream;
 use React\Filesystem\OpenFileLimiter;
 use React\Filesystem\PermissionFlagResolver;
-use React\Filesystem\Stream\StreamFactory;
 use React\Filesystem\TypeDetectorInterface;
 use React\Promise\Deferred;
 
@@ -102,7 +101,7 @@ class Adapter implements AdapterInterface
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public static function isSupported()
     {
@@ -267,9 +266,7 @@ class Adapter implements AdapterInterface
                 $eioFlags,
                 $mode,
             ]);
-        })->then(function ($fileDescriptor) use ($path, $flags) {
-            return StreamFactory::create($path, $fileDescriptor, $flags, $this);
-        }, function ($error) {
+        })->otherwise(function ($error) {
             $this->openFileLimiter->close();
             return \React\Promise\reject($error);
         });

--- a/src/Node/Directory.php
+++ b/src/Node/Directory.php
@@ -240,7 +240,7 @@ class Directory implements DirectoryInterface
 
     /**
      * @param $sourceStream
-     * @return Stream
+     * @return ObjectStream
      */
     protected function processLsRecursiveContents($sourceStream)
     {

--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -7,7 +7,7 @@ use React\Filesystem\AdapterInterface;
 use React\Filesystem\FilesystemInterface;
 use React\Filesystem\ObjectStream;
 use React\Filesystem\ObjectStreamSink;
-use React\Filesystem\Stream\GenericStreamInterface;
+use React\Filesystem\Stream\StreamFactory;
 use React\Promise\Stream;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
@@ -118,10 +118,10 @@ class File implements FileInterface
             return \React\Promise\reject(new Exception('File is already open'));
         }
 
-        return $this->adapter->open($this->path, $flags, $mode)->then(function (GenericStreamInterface $stream) {
+        return $this->adapter->open($this->path, $flags, $mode)->then(function ($fd) use ($flags) {
             $this->open = true;
-            $this->fileDescriptor = $stream->getFiledescriptor();
-            return $stream;
+            $this->fileDescriptor = $fd;
+            return StreamFactory::create($this->path, $fd, $flags, $this->adapter);
         });
     }
 

--- a/src/Stream/GenericStreamTrait.php
+++ b/src/Stream/GenericStreamTrait.php
@@ -48,7 +48,7 @@ trait GenericStreamTrait
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isClosed()
     {
@@ -56,7 +56,7 @@ trait GenericStreamTrait
     }
 
     /**
-     * @param boolean $closed
+     * @param bool $closed
      */
     public function setClosed($closed)
     {


### PR DESCRIPTION
This PR is a split of the original PR #45 (the original PR shall stay open until completely done).

This PR moves the usage of `StreamFactory::create` from `Adapter::open` to `Node\File::open`, which makes the adapters compatible to the adapter interface. I have also gone ahead and replaced `boolean` with `bool` to make PHP code assistance tools happy (since technically `boolean` is seen as class).