### PR TITLE
Use random bytes API for child process file descriptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "react/promise": "~2.2",
     "react/promise-stream": "^1.1",
     "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4",
+    "paragonie/random_compat": "^9.0 || ^2.0",
     "wyrihaximus/react-child-process-pool": "^1.3"
   },
   "require-dev": {

--- a/src/ChildProcess/Adapter.php
+++ b/src/ChildProcess/Adapter.php
@@ -202,16 +202,15 @@ class Adapter implements AdapterInterface
      */
     public function open($path, $flags, $mode = self::CREATION_MODE)
     {
-        $id = null;
-        return \WyriHaximus\React\ChildProcess\Messenger\Factory::parentFromClass(self::CHILD_CLASS_NAME, $this->loop)->then(function (Messenger $messenger) use (&$id, $path, $flags, $mode) {
-            $id = count($this->fileDescriptors);
+        $id = bin2hex(random_bytes(10));
+        return \WyriHaximus\React\ChildProcess\Messenger\Factory::parentFromClass(self::CHILD_CLASS_NAME, $this->loop)->then(function (Messenger $messenger) use ($id, $path, $flags, $mode) {
             $this->fileDescriptors[$id] = $messenger;
             return $this->fileDescriptors[$id]->rpc(Factory::rpc('open', [
                 'path' => $path,
                 'flags' => $flags,
                 'mode' => $mode,
             ]));
-        })->then(function () use (&$id) {
+        })->then(function () use ($id) {
             return $id;
         });
     }


### PR DESCRIPTION
This PR changes the file descriptor from the array size to random bytes. Compatibility is guaranteed through random_compat, although PHP5 support is running out in one month.

Using random bytes guarantees no clashing file descriptors, that means re-using and overwriting a currently active file descriptor.