### PR TITLE
Use native PHP indexing for child process file descriptors

### DIFF
--- a/src/ChildProcess/Adapter.php
+++ b/src/ChildProcess/Adapter.php
@@ -202,17 +202,18 @@ class Adapter implements AdapterInterface
      */
     public function open($path, $flags, $mode = self::CREATION_MODE)
     {
-        $id = null;
-        return \WyriHaximus\React\ChildProcess\Messenger\Factory::parentFromClass(self::CHILD_CLASS_NAME, $this->loop)->then(function (Messenger $messenger) use (&$id, $path, $flags, $mode) {
-            $id = count($this->fileDescriptors);
-            $this->fileDescriptors[$id] = $messenger;
+        return \WyriHaximus\React\ChildProcess\Messenger\Factory::parentFromClass(self::CHILD_CLASS_NAME, $this->loop)->then(function (Messenger $messenger) use ($path, $flags, $mode) {
+            $this->fileDescriptors[] = $messenger;
+            \end($this->fileDescriptors);
+            $id = \key($this->fileDescriptors);
+
             return $this->fileDescriptors[$id]->rpc(Factory::rpc('open', [
                 'path' => $path,
                 'flags' => $flags,
                 'mode' => $mode,
-            ]));
-        })->then(function () use (&$id) {
-            return $id;
+            ]))->then(function () use ($id) {
+                return $id;
+            });
         });
     }
 


### PR DESCRIPTION
This PR is a replacement for #53. As suggested by @clue, we just append to the array and let PHP handle assigning the key.

This PR fixes clashing file descriptors (and therefore overwriting each other) when using the child process adapter.