### PR TITLE
Rename ls to lsStream and make interface-compatible ls method

### DIFF
--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -2,6 +2,7 @@
 
 namespace React\Filesystem;
 
+use React\Filesystem\ObjectStream;
 use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
 
@@ -110,6 +111,14 @@ interface AdapterInterface
      * @return PromiseInterface
      */
     public function ls($path);
+
+    /**
+     * List contents of the given path.
+     *
+     * @param string $path
+     * @return ObjectStream
+     */
+    public function lsStream($path);
 
     /**
      * Touch the given path, either creating a file, or updating mtime on the file.

--- a/src/ChildProcess/Adapter.php
+++ b/src/ChildProcess/Adapter.php
@@ -6,6 +6,7 @@ use DateTime;
 use Exception;
 use React\EventLoop\LoopInterface;
 use React\Filesystem\ObjectStream;
+use React\Filesystem\ObjectStreamSink;
 use React\Filesystem\AdapterInterface;
 use React\Filesystem\CallInvokerInterface;
 use React\Filesystem\FilesystemInterface;
@@ -322,6 +323,15 @@ class Adapter implements AdapterInterface
      * @return PromiseInterface
      */
     public function ls($path)
+    {
+        return ObjectStreamSink::promise($this->lsStream($path));
+    }
+
+    /**
+     * @param string $path
+     * @return ObjectStream
+     */
+    public function lsStream($path)
     {
         $stream = new ObjectStream();
 

--- a/src/Eio/Adapter.php
+++ b/src/Eio/Adapter.php
@@ -10,10 +10,12 @@ use React\Filesystem\FilesystemInterface;
 use React\Filesystem\ModeTypeDetector;
 use React\Filesystem\Node\NodeInterface;
 use React\Filesystem\ObjectStream;
+use React\Filesystem\ObjectStreamSink;
 use React\Filesystem\OpenFileLimiter;
 use React\Filesystem\PermissionFlagResolver;
 use React\Filesystem\TypeDetectorInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 
 class Adapter implements AdapterInterface
 {
@@ -191,9 +193,18 @@ class Adapter implements AdapterInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $path
+     * @return PromiseInterface
      */
     public function ls($path)
+    {
+        return ObjectStreamSink::promise($this->lsStream($path));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function lsStream($path)
     {
         $stream = new ObjectStream();
 

--- a/src/Node/Directory.php
+++ b/src/Node/Directory.php
@@ -69,7 +69,7 @@ class Directory implements DirectoryInterface
      */
     public function ls()
     {
-        return ObjectStreamSink::promise($this->lsStreaming());
+        return $this->adapter->ls($this->path);
     }
 
     /**
@@ -77,7 +77,7 @@ class Directory implements DirectoryInterface
      */
     public function lsStreaming()
     {
-        return $this->adapter->ls($this->path);
+        return $this->adapter->lsStream($this->path);
     }
 
     /**

--- a/tests/Node/DirectoryTest.php
+++ b/tests/Node/DirectoryTest.php
@@ -45,18 +45,39 @@ class DirectoryTest extends TestCase
 
         $filesystem = $this->mockAdapter($loop);
 
-        $lsStream = $this->getMock('React\Filesystem\ObjectStream');
+        $ls = \React\Promise\resolve();
 
         $filesystem
             ->expects($this->once())
             ->method('ls')
+            ->with()
+            ->will($this->returnValue($ls))
+        ;
+
+        $directory = new Directory($path, Filesystem::createFromAdapter($filesystem));
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $directory->ls());
+    }
+
+    public function testLsStream()
+    {
+        $path = '/home/foo/bar';
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+
+        $filesystem = $this->mockAdapter($loop);
+
+        $lsStream = $this->getMock('React\Filesystem\ObjectStream');
+
+        $filesystem
+            ->expects($this->once())
+            ->method('lsStream')
             ->with()
             ->will($this->returnValue($lsStream))
         ;
 
         $directory = new Directory($path, Filesystem::createFromAdapter($filesystem));
 
-        $this->assertInstanceOf('React\Promise\PromiseInterface', $directory->ls());
+        $this->assertInstanceOf('React\Filesystem\ObjectStream', $directory->lsStreaming());
     }
 
     public function testCreate()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,6 +35,7 @@ class TestCase extends PHPUnitTestCase
             'chown',
             'stat',
             'ls',
+            'lsStream',
             'touch',
             'open',
             'read',

--- a/tests/UnknownNodeType.php
+++ b/tests/UnknownNodeType.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Filesystem;
 
 use React\Filesystem\Node\NodeInterface;
-use React\Filesystem\Node\ObjectStream;
+use React\Filesystem\ObjectStream;
 
 class UnknownNodeType implements NodeInterface
 {


### PR DESCRIPTION
This PR makes the `ls` method on the adapters compatible to the interface. However instead of removing a streaming `ls`, a new method was added to provide this feature. That means the equivalent named methods on `Node\Directory` now simply delegate to the adapter methods.

Unit tests have been adapted proportionally.