### PR TITLE
Resolve with array instead of SplObjectStorage (AdapterInterface::ls(), Node\DirectoryInterface::lsRecursive(), Node\NodeInterface::copy, ObjectStreamSink::promise())

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ List contents
 -------------
 
 ```php
-$filesystem->dir(__DIR__)->ls()->then(function (\SplObjectStorage $list) {
+$filesystem->dir(__DIR__)->ls()->then(function (array $list) {
    foreach ($list as $node) {
        echo $node->getPath(), PHP_EOL;
    }

--- a/examples/directory_create_recursive.php
+++ b/examples/directory_create_recursive.php
@@ -13,7 +13,7 @@ $dir = $filesystem->dir($dirName);
 echo 'Creating directory: ' . $dirName, PHP_EOL;
 $dir->createRecursive('rwxrwx---')->then(function () use ($startDir) {
     return $startDir->lsRecursive();
-})->then(function (\SplObjectStorage $list) {
+})->then(function (array $list) {
     foreach ($list as $node) {
         echo $node->getPath(), PHP_EOL;
     }

--- a/examples/directory_ls.php
+++ b/examples/directory_ls.php
@@ -6,7 +6,7 @@ $loop = \React\EventLoop\Factory::create();
 
 $filesystem = \React\Filesystem\Filesystem::create($loop);
 echo 'Using ', get_class($filesystem->getAdapter()), PHP_EOL;
-$filesystem->dir(__DIR__ . DIRECTORY_SEPARATOR . 'tmp')->ls()->then(function (\SplObjectStorage $list) {
+$filesystem->dir(__DIR__ . DIRECTORY_SEPARATOR . 'tmp')->ls()->then(function (array $list) {
     foreach ($list as $node) {
         echo get_class($node), ': ', $node->getPath(), PHP_EOL;
     }

--- a/examples/directory_ls_recursive.php
+++ b/examples/directory_ls_recursive.php
@@ -6,7 +6,7 @@ $loop = \React\EventLoop\Factory::create();
 
 $filesystem = \React\Filesystem\Filesystem::create($loop);
 echo 'Using ', get_class($filesystem->getAdapter()), PHP_EOL;
-$filesystem->dir(dirname(__DIR__))->lsRecursive()->then(function (\SplObjectStorage $list) {
+$filesystem->dir(dirname(__DIR__))->lsRecursive()->then(function (array $list) {
     foreach ($list as $node) {
         echo $node->getPath(), PHP_EOL;
     }

--- a/examples/directory_ls_recursive_regexp_interfaces.php
+++ b/examples/directory_ls_recursive_regexp_interfaces.php
@@ -6,8 +6,10 @@ $loop = \React\EventLoop\Factory::create();
 
 $filesystem = \React\Filesystem\Filesystem::create($loop);
 echo 'Using ', get_class($filesystem->getAdapter()), PHP_EOL;
-$filesystem->dir(dirname(__DIR__))->lsRecursive()->then(function (\SplObjectStorage $list) {
-    $interfaces = new RegexIterator($list, '/.*?Interface.php$/');
+$filesystem->dir(dirname(__DIR__))->lsRecursive()->then(function (array $list) {
+    $iterator = new ArrayIterator($list);
+    $interfaces = new RegexIterator($iterator, '/.*?Interface.php$/');
+
     foreach ($interfaces as $node) {
         echo $node->getPath(), PHP_EOL;
     }

--- a/src/ObjectStreamSink.php
+++ b/src/ObjectStreamSink.php
@@ -13,12 +13,12 @@ class ObjectStreamSink
     public static function promise(ObjectStream $stream)
     {
         $deferred = new Deferred();
-        $list = new \SplObjectStorage();
+        $list = array();
 
-        $stream->on('data', function ($object) use ($list) {
-            $list->attach($object);
+        $stream->on('data', function ($object) use (&$list) {
+            $list[] = $object;
         });
-        $stream->on('end', function () use ($deferred, $list) {
+        $stream->on('end', function () use ($deferred, &$list) {
             $deferred->resolve($list);
         });
 

--- a/tests/Adapters/DirectoryTest.php
+++ b/tests/Adapters/DirectoryTest.php
@@ -21,9 +21,8 @@ class DirectoryTest extends AbstractAdaptersTest
         $path = $this->tmpDir . 'path';
         touch($path);
         $listing = $this->await($filesystem->dir($this->tmpDir)->ls(), $loop);
-        $listing->rewind();
-        $this->assertSame(1, $listing->count());
-        $this->assertSame($path, $listing->current()->getPath());
+        $this->assertSame(1, count($listing));
+        $this->assertSame($path, reset($listing)->getPath());
     }
 
     /**

--- a/tests/ChildProcess/AdapterTest.php
+++ b/tests/ChildProcess/AdapterTest.php
@@ -319,9 +319,8 @@ class AdapterTest extends TestCase
         ]);
 
         $nodes = $this->await($promise, $loop);
-        $nodes->rewind();
 
-        $this->assertEquals(new File('foo.bar/bar.foo', $fs), $nodes->current());
+        $this->assertEquals(new File('foo.bar/bar.foo', $fs), reset($nodes));
     }
 
     public function testLsStream()

--- a/tests/ObjectStreamSinkTest.php
+++ b/tests/ObjectStreamSinkTest.php
@@ -15,12 +15,13 @@ class ObjectStreamSinkTest extends TestCase
         $this->assertInstanceOf('React\Promise\PromiseInterface', $sink);
         $stream->emit('data', [$node]);
         $stream->close();
+
         $nodes = null;
-        $sink->then(function (\SplObjectStorage $list) use (&$nodes) {
+        $sink->then(function ($list) use (&$nodes) {
             $nodes = $list;
         });
-        $nodes->rewind();
-        $this->assertSame(1, $nodes->count());
-        $this->assertSame($node, $nodes->current());
+
+        $this->assertSame(1, count($nodes));
+        $this->assertSame($node, reset($nodes));
     }
 }


### PR DESCRIPTION
As discussed in the comments of #57 - this PR changes `ObjectStreamSink::promise` to resolve with an array, instead of an unexpected `SplObjectStorage`.