### PR TITLE
Add AdapterInterface getters and add Filesystem method to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Filesystem
 ==========
 
-Evented filesystem access utilizing [EIO](http://php.net/eio).
-
 [![Build Status](https://secure.travis-ci.org/reactphp/filesystem.png?branch=master)](http://travis-ci.org/reactphp/filesystem) [![Code Climate](https://codeclimate.com/github/reactphp/filesystem/badges/gpa.svg)](https://codeclimate.com/github/reactphp/filesystem)
+
+[ReactPHP](https://reactphp.org/)'s evented asynchronous, non-blocking filesystem access library.
 
 Table of Contents
 -----------------
@@ -23,7 +23,7 @@ Table of Contents
 Introduction
 ------------
 
-Filesystem WIP for [EIO](http://php.net/eio), keep in mind that this can be very unstable at times and is not stable by a long shot!
+`react/filesystem` is a package to power your application with asynchronous, non-blocking filesystem access. Asynchronous access is enabled by various adapters described below.
 
 Adapters
 ------------
@@ -70,7 +70,7 @@ Which is a convenience method for:
 
 ```php
 $filesystem->file('test.txt')->open('r')->then(function($stream) {
-    return React\Stream\BufferedSink::createPromise($stream);
+    return \React\Stream\BufferedSink::createPromise($stream);
 })->then(function($contents) {
     // ...
 });

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -25,6 +25,21 @@ interface AdapterInterface
     public function getLoop();
 
     /**
+     * Get the relevant filesystem for this adapter.
+     *
+     * @internal
+     * @return FilesystemInterface
+     */
+    public function getFilesystem();
+
+    /**
+     * Get the call invoker for this adapter.
+     *
+     * @return CallInvokerInterface
+     */
+    public function getInvoker();
+
+    /**
      * Set the relevant filesystem for this adapter.
      *
      * @internal
@@ -143,7 +158,7 @@ interface AdapterInterface
     /**
      * Read from the given file descriptor.
      *
-     * @param $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param int $length
      * @param int $offset
      * @return PromiseInterface
@@ -153,7 +168,7 @@ interface AdapterInterface
     /**
      * Write to the given file descriptor.
      *
-     * @param $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param string $data
      * @param int $length
      * @param int $offset
@@ -164,7 +179,7 @@ interface AdapterInterface
     /**
      * Close the given file descriptor.
      *
-     * @param resource $fd
+     * @param mixed $fd
      * @return PromiseInterface
      */
     public function close($fd);

--- a/src/ChildProcess/Adapter.php
+++ b/src/ChildProcess/Adapter.php
@@ -135,6 +135,14 @@ class Adapter implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    public function getFilesystem()
+    {
+        return $this->filesystem;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function setFilesystem(FilesystemInterface $filesystem)
     {
         $this->filesystem = $filesystem;
@@ -143,6 +151,14 @@ class Adapter implements AdapterInterface
             MappedTypeDetector::createDefault($this->filesystem),
             new ModeTypeDetector($this->filesystem),
         ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInvoker()
+    {
+        return $this->invoker;
     }
 
     /**

--- a/src/Eio/Adapter.php
+++ b/src/Eio/Adapter.php
@@ -121,9 +121,25 @@ class Adapter implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    public function getInvoker()
+    {
+        return $this->invoker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function setInvoker(CallInvokerInterface $invoker)
     {
         $this->invoker = $invoker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFilesystem()
+    {
+        return $this->filesystem;
     }
 
     /**

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -52,6 +52,12 @@ interface FilesystemInterface
     public function link($path, Node\NodeInterface $destination);
 
     /**
+     * @param string $path
+     * @return \React\Promise\PromiseInterface
+     */
+    public function constructLink($path);
+
+    /**
      * @param string $filename
      * @return \React\Promise\PromiseInterface
      */

--- a/src/Stream/DuplexStream.php
+++ b/src/Stream/DuplexStream.php
@@ -14,7 +14,7 @@ class DuplexStream extends EventEmitter implements DuplexStreamInterface, Generi
 
     /**
      * @param string $path
-     * @param resource $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param AdapterInterface $filesystem
      */
     public function __construct($path, $fileDescriptor, AdapterInterface $filesystem)

--- a/src/Stream/GenericStreamInterface.php
+++ b/src/Stream/GenericStreamInterface.php
@@ -5,7 +5,7 @@ namespace React\Filesystem\Stream;
 interface GenericStreamInterface
 {
     /**
-     * @return resource
+     * @return mixed
      */
     public function getFiledescriptor();
 }

--- a/src/Stream/GenericStreamTrait.php
+++ b/src/Stream/GenericStreamTrait.php
@@ -13,7 +13,7 @@ trait GenericStreamTrait
 
     /**
      * @param string $path
-     * @param resource $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param AdapterInterface $filesystem
      */
     public function __construct($path, $fileDescriptor, AdapterInterface $filesystem)

--- a/src/Stream/ReadableStream.php
+++ b/src/Stream/ReadableStream.php
@@ -13,7 +13,7 @@ class ReadableStream extends EventEmitter implements GenericStreamInterface, Rea
 
     /**
      * @param string $path
-     * @param resource $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param AdapterInterface $filesystem
      */
     public function __construct($path, $fileDescriptor, AdapterInterface $filesystem)

--- a/src/Stream/StreamFactory.php
+++ b/src/Stream/StreamFactory.php
@@ -8,7 +8,7 @@ class StreamFactory
 {
     /**
      * @param string $path
-     * @param resource $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param int $flags
      * @param AdapterInterface $filesystem
      * @return DuplexStream|ReadableStream|WritableStream

--- a/src/Stream/WritableStream.php
+++ b/src/Stream/WritableStream.php
@@ -13,7 +13,7 @@ class WritableStream extends EventEmitter implements GenericStreamInterface, Wri
 
     /**
      * @param string $path
-     * @param resource $fileDescriptor
+     * @param mixed $fileDescriptor
      * @param AdapterInterface $filesystem
      */
     public function __construct($path, $fileDescriptor, AdapterInterface $filesystem)

--- a/tests/ChildProcess/AdapterTest.php
+++ b/tests/ChildProcess/AdapterTest.php
@@ -36,6 +36,38 @@ class AdapterTest extends TestCase
         $this->assertSame($loop, $filesystem->getLoop());
     }
 
+    public function testGetSetFilesystem()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+        $filesystem = new Adapter($loop, [
+            'pool' => [
+                'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
+            ],
+        ]);
+
+        $this->assertNull($filesystem->getFilesystem());
+        $fs = \React\Filesystem\Filesystem::createFromAdapter($this->mockAdapter());
+        $filesystem->setFilesystem($fs);
+
+        $this->assertSame($fs, $filesystem->getFilesystem());
+    }
+
+    public function testGetSetInvoker()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+        $filesystem = new Adapter($loop, [
+            'pool' => [
+                'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
+            ],
+        ]);
+
+        $invoker = new \React\Filesystem\InstantInvoker($filesystem);
+        $this->assertNotSame($invoker, $filesystem->getInvoker());
+
+        $filesystem->setInvoker($invoker);
+        $this->assertSame($invoker, $filesystem->getInvoker());
+    }
+
     public function callFilesystemProvider()
     {
         return [

--- a/tests/Eio/AdapterTest.php
+++ b/tests/Eio/AdapterTest.php
@@ -35,6 +35,38 @@ class AdapterTest extends TestCase
         $this->assertSame($loop, $filesystem->getLoop());
     }
 
+    public function testGetSetFilesystem()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+        $filesystem = new Adapter($loop, [
+            'pool' => [
+                'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
+            ],
+        ]);
+        
+        $this->assertNull($filesystem->getFilesystem());
+        $fs = \React\Filesystem\Filesystem::createFromAdapter($this->mockAdapter());
+        $filesystem->setFilesystem($fs);
+
+        $this->assertSame($fs, $filesystem->getFilesystem());
+    }
+
+    public function testGetSetInvoker()
+    {
+        $loop = $this->getMock('React\EventLoop\LoopInterface');
+        $filesystem = new Adapter($loop, [
+            'pool' => [
+                'class' => 'WyriHaximus\React\ChildProcess\Pool\Pool\Dummy',
+            ],
+        ]);
+
+        $invoker = new \React\Filesystem\InstantInvoker($filesystem);
+        $this->assertNotSame($invoker, $filesystem->getInvoker());
+
+        $filesystem->setInvoker($invoker);
+        $this->assertSame($invoker, $filesystem->getInvoker());
+    }
+
     public function testCallFilesystemCallsProvider()
     {
         $pathName = 'foo.bar';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,7 +24,9 @@ class TestCase extends PHPUnitTestCase
         $mock = $this->getMock('React\Filesystem\AdapterInterface', [
             '__construct',
             'getLoop',
+            'getFilesystem',
             'setFilesystem',
+            'getInvoker',
             'setInvoker',
             'callFilesystem',
             'isSupported',


### PR DESCRIPTION
This PR adds getters for the setters to the adapter interface (this allows future functional tests to validate the action), and adds the `constructLink` method from the `Filesystem` class to the interface.

This PR also changes the filedescriptor type from `resource` to `mixed` in the docblocks. De facto the file descriptor is an integer currently. But it might be any other type (such as string) from future adapters (de facto string for my pthreads adapter).

Additionally I've taken the freedom to update the readme a little bit.