### PR TITLE
Nightly builds should be allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   allow_failures:
     - php: 5.4
     - php: 7.1
+    - php: nightly
 
 install:
   - ./travis-init.sh


### PR DESCRIPTION
Since nightly is unpredictable, and in it's current state on TravisCI
broken they should be allowed to fail.