### PR TITLE
Drop support for PHP 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,14 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:
   allow_failures:
-    - php: 5.4
-    - php: 7.1
     - php: nightly
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=7.0.0",
     "evenement/evenement": "^3.0 || ^2.0",
     "react/event-loop": "^1.0 || ^0.5 || ^0.4",
     "react/promise": "~2.2",
@@ -39,7 +39,7 @@
   "config": {
     "sort-packages": true,
     "platform": {
-      "php": "5.4"
+      "php": "7.0"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0301b26ae1ada823f6fbeb0b71fc57bb",
+    "content-hash": "8248330aeafb712a02cca0845e72de68",
     "packages": [
         {
             "name": "cakephp/utility",
@@ -1614,6 +1614,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
@@ -2044,10 +2045,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0"
+        "php": ">=7.0.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.4"
+        "php": "7.0"
     }
 }


### PR DESCRIPTION
As one of the goals for `v0.2.0` is to drop PHP 5.x support, this PR lays the foundation for that by dropping the PHP 5.x versions from TravisCI and changing the composer enforced version to 7+.