### PR TITLE
Use Adapter *Contents instead in File Node

### DIFF
--- a/src/Node/File.php
+++ b/src/Node/File.php
@@ -145,9 +145,7 @@ class File implements FileInterface
      */
     public function getContents()
     {
-        return $this->open('r')->then(function ($stream) {
-            return Stream\buffer($stream);
-        });
+        return $this->adapter->getContents($this->path);
     }
 
     /**
@@ -155,10 +153,7 @@ class File implements FileInterface
      */
     public function putContents($contents)
     {
-        return $this->open('cw')->then(function (WritableStreamInterface $stream) use ($contents) {
-            $stream->write($contents);
-            return $this->close();
-        });
+        return $this->adapter->putContents($this->path, $contents);
     }
 
     /**

--- a/tests/Node/FileTest.php
+++ b/tests/Node/FileTest.php
@@ -281,33 +281,10 @@ class FileTest extends TestCase
         $filesystem = $this->mockAdapter();
 
         $filesystem
-            ->expects($this->any())
-            ->method('stat')
+            ->expects($this->once())
+            ->method('getContents')
             ->with($path)
-            ->will($this->returnValue(new FulfilledPromise([
-                'size' => 1,
-            ])))
-        ;
-
-        $filesystem
-            ->expects($this->once())
-            ->method('open')
-            ->with($path, 'r')
-            ->will($this->returnValue(new FulfilledPromise($fd)))
-        ;
-
-        $filesystem
-            ->expects($this->once())
-            ->method('read')
-            ->with($fd, 1, 0)
             ->will($this->returnValue(new FulfilledPromise('a')))
-        ;
-
-        $filesystem
-            ->expects($this->once())
-            ->method('close')
-            ->with($fd)
-            ->will($this->returnValue(new FulfilledPromise()))
         ;
 
         $getContentsPromise = (new File($path, Filesystem::createFromAdapter($filesystem)))->getContents();


### PR DESCRIPTION
This patch updates `Node/File` to use the methods on the `AdapterInterface` instead of open the file for reading or writing and buffer the stream.

Fixes #63.