### PR TITLE
Test on PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         php:
+          - "8.2"
           - "8.1"
           - "8.0"
           - "7.4"


### PR DESCRIPTION
With PHP 8.2 coming out later this year, we should be reading for it's release to ensure all out code works on it.

Refs: https://github.com/reactphp/event-loop/pull/258